### PR TITLE
Fix CI Runner architecture to macos-13

### DIFF
--- a/.github/workflows/appium-tests.yml
+++ b/.github/workflows/appium-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-13
     
     steps:
     - name: Checkout Code


### PR DESCRIPTION
CI is failing because x86_64 emulator cannot run on aarch64 macos-latest runner.