### PR TITLE
Fix parallel execution for single-emulator CI

### DIFF
--- a/testng.xml
+++ b/testng.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
-<suite name="Minimal ToDo Appium Tests" parallel="methods" thread-count="2">
+<suite name="Minimal ToDo Appium Tests" parallel="tests" thread-count="2">
     <test name="Functional Tests">
         <classes>
             <class name="tests.ToDoTests"/>


### PR DESCRIPTION
Resolves #26

Changes `parallel='methods'` to `parallel='tests'` to prevent concurrent Appium sessions from crashing on a single emulator.