### PR TITLE
Fix Allure empty report: register listener and add properties

### DIFF
--- a/src/test/resources/allure.properties
+++ b/src/test/resources/allure.properties
@@ -1,0 +1,1 @@
+allure.results.directory=target/allure-results

--- a/testng.xml
+++ b/testng.xml
@@ -1,5 +1,8 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="Minimal ToDo Appium Tests" parallel="tests" thread-count="2">
+    <listeners>
+        <listener class-name="io.qameta.allure.testng.AllureTestNg"/>
+    </listeners>
     <test name="Functional Tests">
         <classes>
             <class name="tests.ToDoTests"/>


### PR DESCRIPTION
Registers AllureTestNg listener in testng.xml (critical for results capture) and adds allure.properties config file.